### PR TITLE
Add SUPPORTPATH constant for CI 4.6 compatibility

### DIFF
--- a/app/Config/Paths.php
+++ b/app/Config/Paths.php
@@ -98,3 +98,8 @@ class Paths
         return $candidates[0];
     }
 }
+
+// Added automatically for CodeIgniter 4.6+ support directory handling.
+if (! defined('SUPPORTPATH')) {
+    define('SUPPORTPATH', \dirname(__DIR__, 2) . DIRECTORY_SEPARATOR . 'support' . DIRECTORY_SEPARATOR);
+}

--- a/support/.gitkeep
+++ b/support/.gitkeep
@@ -1,0 +1,1 @@
+# Keeps the support directory in version control.


### PR DESCRIPTION
## Summary
- define SUPPORTPATH in the legacy Paths config when it is missing
- add the support directory placeholder so the path is available at runtime

## Testing
- php spark --version *(fails: vendor framework files are not installed in this environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691465108cbc8332ab733a987ed3fce6)