### PR TITLE
Add fallback when Kint debugger is unavailable

### DIFF
--- a/app/Config/Boot/KintGuard.php
+++ b/app/Config/Boot/KintGuard.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+if (! function_exists('kint_guard_detect_init_file')) {
+    /**
+     * Attempts to locate the bundled Kint initialization script shipped with CodeIgniter.
+     */
+    function kint_guard_detect_init_file(): ?string
+    {
+        $candidates = [
+            __DIR__ . '/../../vendor/codeigniter4/framework/system/ThirdParty/Kint/init.php',
+            __DIR__ . '/../../../vendor/codeigniter4/framework/system/ThirdParty/Kint/init.php',
+            dirname(__DIR__, 4) . '/vendor/codeigniter4/framework/system/ThirdParty/Kint/init.php',
+        ];
+
+        foreach ($candidates as $candidate) {
+            if (is_file($candidate)) {
+                return $candidate;
+            }
+        }
+
+        return null;
+    }
+}
+
+if (! function_exists('kint_guard_register_fallback')) {
+    /**
+     * Loads the lightweight fallback helpers that mimic the public Kint API.
+     */
+    function kint_guard_register_fallback(): void
+    {
+        static $registered = false;
+
+        if ($registered) {
+            return;
+        }
+
+        require_once __DIR__ . '/../KintFallback.php';
+
+        if (class_exists('KintFallback')) {
+            KintFallback::notifyMissingLibrary();
+        }
+
+        $registered = true;
+    }
+}

--- a/app/Config/Boot/development.php
+++ b/app/Config/Boot/development.php
@@ -1,5 +1,9 @@
 <?php
 
+require_once __DIR__ . '/KintGuard.php';
+
+$kintAvailable = kint_guard_detect_init_file() !== null;
+
 /*
  |--------------------------------------------------------------------------
  | ERROR DISPLAY
@@ -31,4 +35,8 @@ defined('SHOW_DEBUG_BACKTRACE') || define('SHOW_DEBUG_BACKTRACE', true);
  | the system. This will control whether Kint is loaded, and a few other
  | items. It can always be used within your own application too.
  */
-defined('CI_DEBUG') || define('CI_DEBUG', true);
+defined('CI_DEBUG') || define('CI_DEBUG', $kintAvailable);
+
+if (! $kintAvailable) {
+    kint_guard_register_fallback();
+}

--- a/app/Config/Boot/production.php
+++ b/app/Config/Boot/production.php
@@ -1,5 +1,9 @@
 <?php
 
+require_once __DIR__ . '/KintGuard.php';
+
+$kintAvailable = kint_guard_detect_init_file() !== null;
+
 /*
  |--------------------------------------------------------------------------
  | ERROR DISPLAY
@@ -23,3 +27,7 @@ ini_set('display_errors', '0');
  | release of the framework.
  */
 defined('CI_DEBUG') || define('CI_DEBUG', false);
+
+if (! $kintAvailable) {
+    kint_guard_register_fallback();
+}

--- a/app/Config/Boot/testing.php
+++ b/app/Config/Boot/testing.php
@@ -1,5 +1,9 @@
 <?php
 
+require_once __DIR__ . '/KintGuard.php';
+
+$kintAvailable = kint_guard_detect_init_file() !== null;
+
 /*
  * The environment testing is reserved for PHPUnit testing. It has special
  * conditions built into the framework at various places to assist with that.
@@ -35,4 +39,8 @@ defined('SHOW_DEBUG_BACKTRACE') || define('SHOW_DEBUG_BACKTRACE', true);
  | the system. It's not widely used currently, and may not survive
  | release of the framework.
  */
-defined('CI_DEBUG') || define('CI_DEBUG', true);
+defined('CI_DEBUG') || define('CI_DEBUG', $kintAvailable);
+
+if (! $kintAvailable) {
+    kint_guard_register_fallback();
+}

--- a/app/Config/KintFallback.php
+++ b/app/Config/KintFallback.php
@@ -1,0 +1,120 @@
+<?php
+
+declare(strict_types=1);
+
+if (! class_exists('KintFallback')) {
+    /**
+     * Minimal replacements for Kint helper functions when the package is unavailable.
+     */
+    final class KintFallback
+    {
+        private static bool $notified = false;
+
+        public static function notifyMissingLibrary(): void
+        {
+            if (self::$notified) {
+                return;
+            }
+
+            self::$notified = true;
+            self::write('Kint debugger was not found; using fallback debug helpers.');
+        }
+
+        /**
+         * @return mixed
+         */
+        public static function dump(...$vars)
+        {
+            self::notifyMissingLibrary();
+
+            $result = count($vars) === 1 ? $vars[0] : $vars;
+
+            foreach ($vars as $index => $var) {
+                $output = print_r($var, true);
+                self::write(sprintf('[dump:%d]%s%s', $index + 1, PHP_EOL, $output));
+            }
+
+            return $result;
+        }
+
+        public static function dumpToString(mixed $var): string
+        {
+            self::notifyMissingLibrary();
+
+            return print_r($var, true);
+        }
+
+        public static function trace(): array
+        {
+            self::notifyMissingLibrary();
+
+            $trace = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS);
+            self::write('[trace]' . PHP_EOL . print_r($trace, true));
+
+            return $trace;
+        }
+
+        private static function write(string $message): void
+        {
+            if (PHP_SAPI === 'cli' && defined('STDERR')) {
+                fwrite(STDERR, $message . PHP_EOL);
+
+                return;
+            }
+
+            error_log($message);
+        }
+    }
+}
+
+if (! function_exists('d')) {
+    function d(...$vars)
+    {
+        return KintFallback::dump(...$vars);
+    }
+}
+
+if (! function_exists('dd')) {
+    function dd(...$vars): never
+    {
+        KintFallback::dump(...$vars);
+        exit(1);
+    }
+}
+
+if (! function_exists('s')) {
+    function s(...$vars): array
+    {
+        return array_map(static fn ($var): string => KintFallback::dumpToString($var), $vars);
+    }
+}
+
+if (! function_exists('sd')) {
+    function sd(...$vars): never
+    {
+        KintFallback::dump(...$vars);
+        exit(1);
+    }
+}
+
+if (! function_exists('trace')) {
+    function trace(): array
+    {
+        return KintFallback::trace();
+    }
+}
+
+if (! class_exists('Kint')) {
+    final class Kint
+    {
+        public static function dump(...$vars)
+        {
+            return KintFallback::dump(...$vars);
+        }
+
+        public static function trace(): array
+        {
+            return KintFallback::trace();
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add a bootstrap guard that detects the bundled Kint library and registers a fallback when it is missing
- provide lightweight replacements for the common Kint helper functions to avoid fatal errors when the vendor copy is absent
- update each environment boot file to use the guard and disable CI_DEBUG when Kint cannot be loaded

## Testing
- php -l app/Config/Boot/KintGuard.php
- php -l app/Config/KintFallback.php
- php -l app/Config/Boot/development.php
- php -l app/Config/Boot/testing.php
- php -l app/Config/Boot/production.php

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69146f4212448332aba415380116157c)