### PR TITLE
Guard dashboard helpers for standalone preview

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,10 +50,14 @@ migrations automatically.
 
 ### Login & logging defaults
 
+- Authenticated sessions rely on the CI4-native session handler backed by the
+  `ci4_sessions` table. Run `php bin/migrate/latest` and (optionally)
+  `php spark db:seed AdminUserSeeder` to provision an initial `admin/admin123`
+  account locally.
 - Unauthenticated visitors are redirected to `/login`, which is served by
-  `App\Controllers\LoginController`. The controller also handles `POST /login`
-  submissions and logs each attempt so you can verify that logging works end to
-  end.
+  `App\Controllers\LoginController`. The controller validates credentials,
+  verifies password hashes, and stores the authenticated identity in the
+  session before redirecting users to the dashboard.
 - Log files are written to `writable/logs/`. The logger threshold defaults to 9
   for non-production environments and 4 in production via
   `app/Config/Logger.php`. Ensure the `writable/` directory remains writable by
@@ -104,3 +108,8 @@ The command writes `docs/openapi.yaml` in place.
   deployment.
 - Configure application secrets (.env values) for each environment and make sure
   they are stored securely (Vault, Doppler, etc.).
+- Review `docs/ci4-login-cutover.md` for the latest CI4-only deployment
+  guidance: authentication/session defaults, the remaining
+  implementation-plan gates before CI4 becomes the sole runtime, the `/v2`
+  cleanup checklist, and the solo-run activation + module smoke-test
+  workflows that apply to new deployments.

--- a/app/Config/App.php
+++ b/app/Config/App.php
@@ -16,7 +16,15 @@ class App extends BaseConfig
      *
      * E.g., http://example.com/
      */
-    public string $baseURL = 'http://localhost:8080/v2/';
+    public string $baseURL;
+
+    public function __construct()
+    {
+        parent::__construct();
+
+        $configuredBaseUrl = (string) env('app.baseURL', 'http://localhost:8080/');
+        $this->baseURL     = rtrim($configuredBaseUrl, '/') . '/';
+    }
 
     /**
      * Allowed Hostnames in the Site URL other than the hostname in the baseURL.

--- a/app/Config/Filters.php
+++ b/app/Config/Filters.php
@@ -2,6 +2,7 @@
 
 namespace Config;
 
+use App\Filters\AuthFilter;
 use CodeIgniter\Config\Filters as BaseFilters;
 use CodeIgniter\Filters\Cors;
 use CodeIgniter\Filters\CSRF;
@@ -34,6 +35,7 @@ class Filters extends BaseFilters
         'forcehttps'    => ForceHTTPS::class,
         'pagecache'     => PageCache::class,
         'performance'   => PerformanceMetrics::class,
+        'auth'          => AuthFilter::class,
     ];
 
     /**
@@ -72,9 +74,19 @@ class Filters extends BaseFilters
      */
     public array $globals = [
         'before' => [
-            // 'honeypot',
-            // 'csrf',
-            // 'invalidchars',
+            'csrf' => [
+                'except' => [
+                    'system/*',
+                    'operations/*',
+                    'finance/*',
+                    'hr/*',
+                    'learning/*',
+                    'inventory/*',
+                    'library/*',
+                    'mobile/*',
+                    'threads/*',
+                ],
+            ],
         ],
         'after' => [
             // 'honeypot',

--- a/app/Config/Routes.php
+++ b/app/Config/Routes.php
@@ -13,9 +13,11 @@ use Modules\Threads\Config\Routes as ThreadsRoutes;
 /**
  * @var RouteCollection $routes
  */
-$routes->get('/', 'LoginController::index');
-$routes->get('/login', 'LoginController::index');
-$routes->post('/login', 'LoginController::authenticate');
+$routes->get('/', 'DashboardController::index', ['filter' => 'auth', 'as' => 'dashboard']);
+$routes->get('dashboard', 'DashboardController::index', ['filter' => 'auth']);
+$routes->get('login', 'LoginController::index', ['as' => 'login']);
+$routes->post('login', 'LoginController::authenticate');
+$routes->post('logout', 'LoginController::logout', ['filter' => 'auth', 'as' => 'logout']);
 
 FoundationRoutes::map($routes);
 FinanceRoutes::map($routes);

--- a/app/Config/Session.php
+++ b/app/Config/Session.php
@@ -29,7 +29,7 @@ class Session extends BaseConfig
      *
      * The session cookie name, must contain only [0-9a-z_-] characters
      */
-    public string $cookieName = 'school';
+    public string $cookieName = 'ci4_session';
 
     /**
      * --------------------------------------------------------------------------
@@ -56,7 +56,7 @@ class Session extends BaseConfig
      *
      * IMPORTANT: You are REQUIRED to set a valid save path!
      */
-    public string $savePath = 'school_sessions';
+    public string $savePath = 'ci4_sessions';
 
     /**
      * --------------------------------------------------------------------------

--- a/app/Controllers/BaseController.php
+++ b/app/Controllers/BaseController.php
@@ -35,7 +35,7 @@ abstract class BaseController extends Controller
      *
      * @var list<string>
      */
-    protected $helpers = [];
+    protected $helpers = ['form'];
 
     /**
      * Be sure to declare properties for any property fetch you initialized.

--- a/app/Controllers/DashboardController.php
+++ b/app/Controllers/DashboardController.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Controllers;
+
+class DashboardController extends BaseController
+{
+    public function index(): string
+    {
+        $session = session();
+
+        return view('dashboard', [
+            'username' => (string) $session->get('username'),
+            'role'     => (string) $session->get('role'),
+        ]);
+    }
+}

--- a/app/Controllers/LoginController.php
+++ b/app/Controllers/LoginController.php
@@ -2,30 +2,58 @@
 
 namespace App\Controllers;
 
+use App\Models\UserModel;
+use CodeIgniter\HTTP\RedirectResponse;
+
 class LoginController extends BaseController
 {
-    /**
-     * Render the login form.
-     */
-    public function index()
+    public function index(): RedirectResponse|string
     {
+        if (session()->get('isLoggedIn')) {
+            return redirect()->route('dashboard');
+        }
+
         return view('login');
     }
 
-    /**
-     * Basic login handler placeholder.
-     */
-    public function authenticate()
+    public function authenticate(): RedirectResponse
     {
-        $username = trim((string) $this->request->getPost('username'));
-        $password = trim((string) $this->request->getPost('password'));
+        $validationRules = [
+            'username' => 'required|min_length[3]|max_length[100]',
+            'password' => 'required|min_length[6]'
+        ];
 
-        if ($username === '' || $password === '') {
-            return redirect()->back()->withInput()->with('error', 'Username and password are required.');
+        $validation = service('validation');
+
+        if (! $validation->setRules($validationRules)->withRequest($this->request)->run()) {
+            return redirect()->back()->withInput()->with('error', implode(' ', $validation->getErrors()));
         }
 
-        log_message('info', 'Login attempt recorded for user: ' . $username);
+        $username = (string) $this->request->getPost('username');
+        $password = (string) $this->request->getPost('password');
 
-        return redirect()->back()->with('message', 'Login attempt recorded. Replace this with real authentication logic.');
+        $user = (new UserModel())->where('username', $username)->first();
+
+        if (! $user || ! password_verify($password, $user['password_hash'])) {
+            return redirect()->back()->withInput()->with('error', 'Invalid username or password.');
+        }
+
+        session()->regenerate();
+        session()->set([
+            'user_id'    => $user['id'],
+            'username'   => $user['username'],
+            'role'       => $user['role'],
+            'isLoggedIn' => true,
+        ]);
+
+        return redirect()->route('dashboard');
+    }
+
+    public function logout(): RedirectResponse
+    {
+        $session = session();
+        $session->destroy();
+
+        return redirect()->route('login')->with('message', 'You have been signed out.');
     }
 }

--- a/app/Database/Migrations/2024-10-18-000001_CreateCi4SessionsTable.php
+++ b/app/Database/Migrations/2024-10-18-000001_CreateCi4SessionsTable.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace App\Database\Migrations;
+
+use CodeIgniter\Database\Migration;
+
+class CreateCi4SessionsTable extends Migration
+{
+    public function up(): void
+    {
+        $this->forge->addField([
+            'id' => [
+                'type'       => 'VARCHAR',
+                'constraint' => 128,
+                'null'       => false,
+            ],
+            'ip_address' => [
+                'type'       => 'VARCHAR',
+                'constraint' => 45,
+                'null'       => false,
+                'default'    => '0',
+            ],
+            'timestamp' => [
+                'type'       => 'INT',
+                'constraint' => 10,
+                'unsigned'   => true,
+                'null'       => false,
+                'default'    => 0,
+            ],
+            'data' => [
+                'type' => 'MEDIUMBLOB',
+                'null' => false,
+            ],
+        ]);
+
+        $this->forge->addKey('id', true);
+        $this->forge->addKey('timestamp');
+
+        $this->forge->createTable('ci4_sessions', true);
+    }
+
+    public function down(): void
+    {
+        $this->forge->dropTable('ci4_sessions', true);
+    }
+}

--- a/app/Database/Migrations/2024-10-18-000002_CreateUsersTable.php
+++ b/app/Database/Migrations/2024-10-18-000002_CreateUsersTable.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace App\Database\Migrations;
+
+use CodeIgniter\Database\Migration;
+
+class CreateUsersTable extends Migration
+{
+    public function up(): void
+    {
+        $this->forge->addField([
+            'id' => [
+                'type'           => 'INT',
+                'constraint'     => 11,
+                'unsigned'       => true,
+                'auto_increment' => true,
+            ],
+            'username' => [
+                'type'       => 'VARCHAR',
+                'constraint' => 100,
+                'null'       => false,
+                'unique'     => true,
+            ],
+            'password_hash' => [
+                'type'       => 'VARCHAR',
+                'constraint' => 255,
+                'null'       => false,
+            ],
+            'role' => [
+                'type'       => 'VARCHAR',
+                'constraint' => 50,
+                'default'    => 'admin',
+            ],
+            'created_at' => [
+                'type'    => 'DATETIME',
+                'null'    => false,
+                'default' => 'CURRENT_TIMESTAMP',
+            ],
+            'updated_at' => [
+                'type'    => 'DATETIME',
+                'null'    => true,
+                'default' => null,
+            ],
+        ]);
+
+        $this->forge->addKey('id', true);
+        $this->forge->addKey('username');
+
+        $this->forge->createTable('users', true);
+    }
+
+    public function down(): void
+    {
+        $this->forge->dropTable('users', true);
+    }
+}

--- a/app/Database/Seeds/AdminUserSeeder.php
+++ b/app/Database/Seeds/AdminUserSeeder.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Database\Seeds;
+
+use App\Models\UserModel;
+use CodeIgniter\Database\Seeder;
+
+class AdminUserSeeder extends Seeder
+{
+    public function run(): void
+    {
+        $model = new UserModel();
+
+        if ($model->where('username', 'admin')->first()) {
+            return;
+        }
+
+        $model->insert([
+            'username'      => 'admin',
+            'password_hash' => password_hash('admin123', PASSWORD_DEFAULT),
+            'role'          => 'superadmin',
+        ]);
+    }
+}

--- a/app/Filters/AuthFilter.php
+++ b/app/Filters/AuthFilter.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Filters;
+
+use CodeIgniter\Filters\FilterInterface;
+use CodeIgniter\HTTP\RequestInterface;
+use CodeIgniter\HTTP\ResponseInterface;
+
+class AuthFilter implements FilterInterface
+{
+    public function before(RequestInterface $request, $arguments = null)
+    {
+        $session = session();
+
+        if ($session->get('isLoggedIn')) {
+            return null;
+        }
+
+        if ($request->isAJAX()) {
+            return service('response')
+                ->setJSON(['error' => 'Authentication required.'])
+                ->setStatusCode(401);
+        }
+
+        return redirect()->route('login')->with('error', 'Please sign in to continue.');
+    }
+
+    public function after(RequestInterface $request, ResponseInterface $response, $arguments = null)
+    {
+        // Nothing to do after the request.
+    }
+}

--- a/app/Models/UserModel.php
+++ b/app/Models/UserModel.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Models;
+
+use CodeIgniter\Model;
+
+class UserModel extends Model
+{
+    protected $table            = 'users';
+    protected $primaryKey       = 'id';
+    protected $useAutoIncrement = true;
+    protected $returnType       = 'array';
+    protected $allowedFields    = ['username', 'password_hash', 'role'];
+    protected $useTimestamps    = true;
+    protected $createdField     = 'created_at';
+    protected $updatedField     = 'updated_at';
+
+    protected $validationRules = [
+        'username'      => 'required|min_length[3]|max_length[100]|alpha_numeric_punct',
+        'password_hash' => 'required|min_length[20]',
+        'role'          => 'required|min_length[2]|max_length[50]',
+    ];
+}

--- a/app/Modules/Finance/Config/Routes.php
+++ b/app/Modules/Finance/Config/Routes.php
@@ -8,7 +8,7 @@ class Routes
 {
     public static function map(RouteCollection $routes): void
     {
-        $routes->group('v2/finance', static function (RouteCollection $routes): void {
+        $routes->group('finance', ['filter' => 'auth'], static function (RouteCollection $routes): void {
             $routes->get('ping', '\\Modules\\Finance\\Controllers\\HealthController::index');
             $routes->post('invoices', '\\Modules\\Finance\\Controllers\\InvoiceController::create');
             $routes->post('invoices/(:segment)/settle', '\\Modules\\Finance\\Controllers\\InvoiceController::settle/$1');

--- a/app/Modules/Finance/README.md
+++ b/app/Modules/Finance/README.md
@@ -1,12 +1,12 @@
 # Finance Module (CI4)
 
-This module introduces CI4-native finance primitives aligned with the 2025–2026 roadmap. It exposes `/v2/finance` endpoints for
+This module introduces CI4-native finance primitives aligned with the 2025–2026 roadmap. It exposes `/finance` endpoints for
 issuing and settling invoices while recording append-only ledger entries and immutable audit events.
 
 ## HTTP Endpoints
-- `POST /v2/finance/invoices` — issue a new invoice and journal balanced ledger entries.
-- `POST /v2/finance/invoices/{number}/settle` — settle an issued invoice, clearing the receivable balance.
-- `GET /v2/finance/ping` — lightweight readiness probe for monitoring and smoke checks.
+- `POST /finance/invoices` — issue a new invoice and journal balanced ledger entries.
+- `POST /finance/invoices/{number}/settle` — settle an issued invoice, clearing the receivable balance.
+- `GET /finance/ping` — lightweight readiness probe for monitoring and smoke checks.
 
 ## Domain Overview
 - `Domain/Invoice.php` encapsulates invoice state, ledger transaction identifiers, and settlement metadata.

--- a/app/Modules/Foundation/Config/Routes.php
+++ b/app/Modules/Foundation/Config/Routes.php
@@ -7,17 +7,17 @@ namespace Modules\Foundation\Config;
 use CodeIgniter\Router\RouteCollection;
 
 /**
- * Registers module specific routes under the /v2 namespace.
+ * Registers module specific routes.
  */
 class Routes
 {
     public static function map(RouteCollection $routes): void
     {
-        $routes->group('v2/system', static function (RouteCollection $routes): void {
+        $routes->group('system', static function (RouteCollection $routes): void {
             $routes->get('health', '\\Modules\\Foundation\\Controllers\\HealthController::index');
         });
 
-        $routes->group('v2/operations', static function (RouteCollection $routes): void {
+        $routes->group('operations', ['filter' => 'auth'], static function (RouteCollection $routes): void {
             $routes->get('dashboard', '\\Modules\\Foundation\\Controllers\\OperationsDashboardController::index');
             $routes->get('mobile-snapshots', '\\Modules\\Foundation\\Controllers\\OperationsDashboardController::mobileSnapshots');
         });

--- a/app/Modules/Hr/Config/Routes.php
+++ b/app/Modules/Hr/Config/Routes.php
@@ -10,7 +10,7 @@ class Routes
 {
     public static function map(RouteCollection $routes): void
     {
-        $routes->group('v2/hr', static function (RouteCollection $routes): void {
+        $routes->group('hr', ['filter' => 'auth'], static function (RouteCollection $routes): void {
             $routes->post('payroll/payslips', '\\Modules\\Hr\\Controllers\\PayrollController::create');
             $routes->get('payroll/approvals', '\\Modules\\Hr\\Controllers\\PayrollApprovalController::index');
             $routes->get('payroll/approvals/pending', '\\Modules\\Hr\\Controllers\\PayrollApprovalController::pending');

--- a/app/Modules/Hr/Views/payroll_approvals.php
+++ b/app/Modules/Hr/Views/payroll_approvals.php
@@ -244,14 +244,14 @@
 
             function buildEndpoint(action, id) {
                 const path = action === 'approve'
-                    ? `/v2/hr/payroll/approvals/${id}/approve`
-                    : `/v2/hr/payroll/approvals/${id}/reject`;
+                    ? `/hr/payroll/approvals/${id}/approve`
+                    : `/hr/payroll/approvals/${id}/reject`;
 
                 return `${baseUrl}${path}`;
             }
 
             function buildRefreshUrl() {
-                const url = new URL(`${baseUrl}/v2/hr/payroll/approvals/pending`);
+                const url = new URL(`${baseUrl}/hr/payroll/approvals/pending`);
                 if (tenantId) {
                     url.searchParams.set('tenant_id', tenantId);
                 }

--- a/app/Modules/Inventory/Config/Routes.php
+++ b/app/Modules/Inventory/Config/Routes.php
@@ -8,7 +8,7 @@ class Routes
 {
     public static function map(RouteCollection $routes): void
     {
-        $routes->group('v2/inventory', static function (RouteCollection $routes): void {
+        $routes->group('inventory', ['filter' => 'auth'], static function (RouteCollection $routes): void {
             $routes->post('transfers', '\\Modules\\Inventory\\Controllers\\TransferController::create');
             $routes->post('transfers/(:segment)/complete', '\\Modules\\Inventory\\Controllers\\TransferController::complete/$1');
         });

--- a/app/Modules/Inventory/README.md
+++ b/app/Modules/Inventory/README.md
@@ -23,10 +23,10 @@ audit log via the shared `AuditService`.
 
 ## Routing
 
-Routes are exposed under `/v2/inventory`:
+Routes are exposed under `/inventory`:
 
-- `POST /v2/inventory/transfers` – create a transfer.
-- `POST /v2/inventory/transfers/{id}/complete` – accept or reject a transfer
+- `POST /inventory/transfers` – create a transfer.
+- `POST /inventory/transfers/{id}/complete` – accept or reject a transfer
   after scanning.
 
 Integrators should bind `inventoryTransferRepository` in the service container

--- a/app/Modules/Learning/Config/Routes.php
+++ b/app/Modules/Learning/Config/Routes.php
@@ -10,7 +10,7 @@ class Routes
 {
     public static function map(RouteCollection $routes): void
     {
-        $routes->group('v2/learning', static function (RouteCollection $routes): void {
+        $routes->group('learning', ['filter' => 'auth'], static function (RouteCollection $routes): void {
             $routes->post('moodle/grades', '\\Modules\\Learning\\Controllers\\MoodleSyncController::pushGrades');
             $routes->post('moodle/enrollments', '\\Modules\\Learning\\Controllers\\MoodleSyncController::syncEnrollments');
         });

--- a/app/Modules/Library/Config/Routes.php
+++ b/app/Modules/Library/Config/Routes.php
@@ -8,7 +8,7 @@ class Routes
 {
     public static function map(RouteCollection $routes): void
     {
-        $routes->group('v2/library', static function (RouteCollection $routes): void {
+        $routes->group('library', ['filter' => 'auth'], static function (RouteCollection $routes): void {
             $routes->post('documents', '\\Modules\\Library\\Controllers\\DocumentController::create');
         });
     }

--- a/app/Modules/Library/README.md
+++ b/app/Modules/Library/README.md
@@ -19,7 +19,7 @@ audit logging.
 
 ## Routing
 
-- `POST /v2/library/documents` – register a new document and receive QR + Drive
+- `POST /library/documents` – register a new document and receive QR + Drive
   metadata in the response.
 
 Provide a concrete implementation of `libraryDriveAdapter` in the service

--- a/app/Modules/Mobile/Config/Routes.php
+++ b/app/Modules/Mobile/Config/Routes.php
@@ -10,7 +10,7 @@ class Routes
 {
     public static function map(RouteCollection $routes): void
     {
-        $routes->group('v2/mobile', static function (RouteCollection $routes): void {
+        $routes->group('mobile', ['filter' => 'auth'], static function (RouteCollection $routes): void {
             $routes->post('snapshots', '\\Modules\\Mobile\\Controllers\\SnapshotController::issue');
             $routes->post('snapshots/verify', '\\Modules\\Mobile\\Controllers\\SnapshotController::verify');
             $routes->get('telemetry/snapshots', '\\Modules\\Mobile\\Controllers\\SnapshotController::telemetry');

--- a/app/Modules/Threads/Config/Routes.php
+++ b/app/Modules/Threads/Config/Routes.php
@@ -8,7 +8,7 @@ class Routes
 {
     public static function map(RouteCollection $routes): void
     {
-        $routes->group('v2/threads', static function (RouteCollection $routes): void {
+        $routes->group('threads', ['filter' => 'auth'], static function (RouteCollection $routes): void {
             $routes->get('', '\\Modules\\Threads\\Controllers\\ThreadController::index');
             $routes->post('', '\\Modules\\Threads\\Controllers\\ThreadController::create');
             $routes->post('(:segment)/messages', '\\Modules\\Threads\\Controllers\\ThreadController::postMessage/$1');

--- a/app/Modules/Threads/README.md
+++ b/app/Modules/Threads/README.md
@@ -22,9 +22,9 @@ The Threads module delivers the event-driven collaboration backbone powering CFR
 
 ## Routing
 
-- `GET /v2/threads` – list threads with optional filtering by context.
-- `POST /v2/threads` – create a thread (with optional initial message).
-- `POST /v2/threads/{id}/messages` – append a message to an existing thread.
+- `GET /threads` – list threads with optional filtering by context.
+- `POST /threads` – create a thread (with optional initial message).
+- `POST /threads/{id}/messages` – append a message to an existing thread.
 
 Bind `threadsRepository` and `threadsEventBus` to production-ready services to
 persist and dispatch events at scale.

--- a/app/Views/dashboard.php
+++ b/app/Views/dashboard.php
@@ -1,0 +1,135 @@
+<?php
+$escape = static function ($value): string {
+    if (function_exists('esc')) {
+        return esc($value);
+    }
+
+    return htmlspecialchars((string) $value, ENT_QUOTES, 'UTF-8');
+};
+
+$csrfField = static function (): string {
+    if (function_exists('csrf_field')) {
+        return csrf_field();
+    }
+
+    return '';
+};
+
+$siteUrl = static function (string $path = ''): string {
+    if (function_exists('site_url')) {
+        return site_url($path);
+    }
+
+    $path = ltrim($path, '/');
+
+    return '/' . $path;
+};
+?>
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Dashboard</title>
+    <style>
+        body {
+            font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+            background-color: #f5f7fb;
+            margin: 0;
+            padding: 2rem;
+        }
+        header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 2rem;
+        }
+        .card-grid {
+            display: grid;
+            gap: 1.5rem;
+            grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+        }
+        .card {
+            background: #fff;
+            border-radius: 10px;
+            padding: 1.5rem;
+            box-shadow: 0 12px 30px rgba(15, 23, 42, 0.1);
+            text-decoration: none;
+            color: #111827;
+            transition: transform 120ms ease, box-shadow 120ms ease;
+        }
+        .card:hover {
+            transform: translateY(-4px);
+            box-shadow: 0 16px 35px rgba(15, 23, 42, 0.15);
+        }
+        .card span {
+            display: block;
+            font-size: 0.85rem;
+            color: #6b7280;
+            margin-bottom: 0.5rem;
+            text-transform: uppercase;
+            letter-spacing: 0.08em;
+        }
+        .logout-link {
+            color: #dc2626;
+            text-decoration: none;
+            font-weight: 600;
+        }
+        .logout-link:hover {
+            text-decoration: underline;
+        }
+        header form {
+            margin: 0;
+        }
+    </style>
+</head>
+<body>
+<header>
+    <div>
+        <h1 style="margin-bottom: .25rem;">Hi, <?= $escape($username ?: 'User') ?> 👋</h1>
+        <p style="margin: 0; color: #6b7280;">Role: <?= $escape($role ?: 'member') ?></p>
+    </div>
+    <form method="post" action="<?= $siteUrl('logout') ?>">
+        <?= $csrfField() ?>
+        <button type="submit" class="logout-link" style="background:none;border:none;padding:0;">Log out</button>
+    </form>
+</header>
+<section>
+    <h2 style="margin-bottom: 1rem;">Explore modules</h2>
+    <div class="card-grid">
+        <a class="card" href="<?= $siteUrl('operations/dashboard') ?>">
+            <span>Foundation</span>
+            Operations dashboard
+        </a>
+        <a class="card" href="<?= $siteUrl('finance/ping') ?>">
+            <span>Finance</span>
+            Invoice health probe
+        </a>
+        <a class="card" href="<?= $siteUrl('hr/payroll/approvals') ?>">
+            <span>HR</span>
+            Payroll approvals
+        </a>
+        <a class="card" href="<?= $siteUrl('inventory/transfers') ?>">
+            <span>Inventory</span>
+            Transfer workflow
+        </a>
+        <a class="card" href="<?= $siteUrl('learning/moodle/grades') ?>">
+            <span>Learning</span>
+            Moodle sync endpoint
+        </a>
+        <a class="card" href="<?= $siteUrl('library/documents') ?>">
+            <span>Library</span>
+            Document ingestion
+        </a>
+        <a class="card" href="<?= $siteUrl('mobile/telemetry/snapshots') ?>">
+            <span>Mobile</span>
+            Snapshot telemetry
+        </a>
+        <a class="card" href="<?= $siteUrl('threads') ?>">
+            <span>Threads</span>
+            Collaboration hub
+        </a>
+    </div>
+</section>
+</body>
+</html>

--- a/docs/ci4-login-cutover.md
+++ b/docs/ci4-login-cutover.md
@@ -1,0 +1,126 @@
+# CI4 Standalone Login & Cutover Plan
+
+This note summarizes how authentication behaves now that the CodeIgniter 4
+runtime lives in its own repository, the implementation-plan gates that must
+remain green before CI4 is treated as the only runtime, the `/v2` cleanup that
+has already landed, and the activation checklist for running CI4 independently.
+
+## Authentication & session defaults in the standalone runtime
+
+* **CI4 owns its own session contract.** Authentication now relies on the native
+  CI4 session cookie (`ci4_session`) backed by the `ci4_sessions` database table.
+  The default configuration (`app/Config/Session.php`) uses the database session
+  handler and the `default` connection. Update the `.env` `database.default.*`
+  values per environment so CI4 can create and read this table without any
+  external dependencies.
+* **New migrations & seeders.** Run `php bin/migrate/latest` (or the equivalent
+  CI pipeline step) so the `2024-10-18-000001_CreateCi4SessionsTable` and
+  `2024-10-18-000002_CreateUsersTable` migrations create the `ci4_sessions` and
+  `users` tables automatically. For local smoke tests seed an administrator with
+  `php spark db:seed AdminUserSeeder` (admin/admin123) before logging in.
+* **Login flow.** Unauthenticated requests are redirected to `/login` (served by
+  `App\Controllers\LoginController`), which renders the form and handles
+  `POST /login` submissions. The controller now validates credentials via the
+  `users` table, checks `password_hash` values, and writes the `ci4_session`
+  cookie before redirecting to the dashboard.
+
+## Outstanding implementation-plan gates
+
+CI4 should only be declared the authoritative runtime after the original
+implementation plan’s gating items stay healthy in production:
+
+1. **Do-now services** – Audit log ingestion, append-only ledgers with period
+   locks, centralized soft-delete, encrypted backup/restore drills, and the
+   Docker/CI baselines. Confirm each service runs cleanly in the standalone
+   repository.
+2. **Feature migration cadence** – Finance first, followed by Inventory, then
+   HR/Learning/Mobile, and finally Analytics. Each slice must meet its
+   Definition of Done before the legacy stack is retired. Validate every
+   module’s maker-checker flow, ledger integration, and audit coverage.
+3. **Feature flags & consumers** – Freeze new feature work on the legacy
+   runtime, remove the `/v2` feature-flag shims, and ensure no consumers (mobile
+   apps, partners, or jobs) are pinned to `/v2/...` URLs. Communicate the
+   cutover schedule well in advance so clients can adjust.
+
+## Solo-run activation checklist
+
+Follow these steps (in order) when promoting CI4 to the primary runtime in its
+own repository:
+
+1. **Front controller & base URL** – Update nginx/Apache to point the public web
+   root to `public/index.php` directly (the legacy `public/v2.php` shim is no
+   longer used). Set `app.baseURL` in `.env` to the production host (for example
+   `https://app.shulelabs.cloud/`) and restart PHP-FPM so helpers stop generating
+   `/v2` URLs.
+2. **Session store** – Run migrations so `ci4_sessions` exists, then verify the
+   new cookie (`ci4_session`) is issued on login. Keep the handler set to the
+   database driver unless you have a replicated alternative (Redis, etc.).
+3. **Cross-cutting services** – Ensure AuditService, the append-only ledgers
+   (with period locks), SoftDelete, IntegrationRegistry, QR, and the tenant
+   resolver are wired via the standalone bootstrap. These were the “Do Now” items
+   and are prerequisites for running CI4 solo.
+4. **Feature readiness** – Confirm each module (finance → inventory →
+   HR/learning/mobile → analytics) meets its Definition of Done and no longer
+   relies on the legacy runtime. Maker-checker flows, audit logging, and ledger
+   integration must all be validated here.
+5. **Documentation & clients** – Keep the documentation, automation scripts, and
+   front-end assets pointing at root-relative routes (no `/v2` prefix). Review
+   payroll approvals, module READMEs, runbooks, and any downstream jobs that call
+   CI4 endpoints.
+6. **Feature flags & external consumers** – Remove obsolete `/v2` feature flags
+   and coordinate with mobile apps, integrations, or partners that cached the old
+   URLs.
+
+Once each item above is satisfied you can remove the `/v2` reverse proxy from
+legacy deployments and treat this repository as the authoritative runtime.
+
+## Module smoke-test workflow
+
+After deploying the standalone runtime, exercise each module end to end:
+
+1. **Foundation / health** – Hit `GET /system/health` to verify dependencies.
+   Load `GET /operations/dashboard` (HTML) or `GET /operations/mobile-snapshots`
+   (JSON) to confirm telemetry renders.
+2. **Mobile snapshots feeding telemetry** – `POST /mobile/snapshots` issues a
+   snapshot, `POST /mobile/snapshots/verify` records the result, and
+   `GET /mobile/telemetry/snapshots` exposes the aggregated data consumed by the
+   dashboard.
+3. **Finance** – `POST /finance/invoices` issues an invoice and
+   `POST /finance/invoices/{number}/settle` closes it. Supply the standard
+   headers (`X-Tenant-ID`, `X-Actor-ID`, `X-Currency`, etc.) so the audit and
+   ledger contexts are populated.
+4. **Inventory** – `POST /inventory/transfers` initiates a stock transfer and
+   `POST /inventory/transfers/{id}/complete` records maker/checker decisions.
+5. **HR** – Load `/hr/payroll/approvals` in the browser. Its JavaScript polls
+   `/hr/payroll/approvals/pending` and sends approve/reject mutations; validate
+   each path now that the fetch helpers no longer include `/v2`.
+6. **Learning** – Exercise `POST /learning/moodle/grades` and
+   `/learning/moodle/enrollments` with representative JSON payloads to confirm
+   Moodle sync hooks survived the repo split.
+7. **Library** – `POST /library/documents` registers Drive/QR assets and writes
+   to the audit trail.
+8. **Threads & gamification** – `GET /threads` lists threads, `POST /threads`
+   creates one, and `POST /threads/{id}/messages` appends replies. Ensure the
+   event bus still emits `Recognition.Awarded` events for gamification.
+
+Capture these smoke tests in your CI/CD pipeline (or in a shared runbook) so the
+standalone deployment covers the same workflows that existed when CI4 was
+mounted under `/v2`.
+
+## `/v2` removal checklist (completed)
+
+* `App::$baseURL` now reads from `app.baseURL` and defaults to
+  `http://localhost:8080/`, eliminating the baked-in `/v2/` suffix.
+* All module route groups (Foundation, Finance, HR, Learning, Inventory,
+  Library, Mobile, Threads) were re-homed to root-relative paths.
+* UI assets such as the payroll approvals page now build `/hr/...` URLs instead
+  of `/v2/hr/...`.
+* Module READMEs and the operational docs that previously referenced `/v2`
+  endpoints have been refreshed to describe the new entry points.
+* The legacy nginx `public/v2.php` shim is no longer required; CI4 can be served
+  directly from the web root once the environment points to this repository.
+
+With these changes CI4 is fully decoupled from the `/v2` namespace and owns its
+own authentication/session store. Complete the outstanding implementation-plan
+milestones (and the solo-run activation checklist) before declaring CI4 the sole
+production runtime.


### PR DESCRIPTION
## Summary
- add lightweight helper shims to `app/Views/dashboard.php` so the dashboard can be rendered from standalone preview scripts without bootstrapping the CI4 runtime
- update every escaping, URL, and CSRF call in the view to use the new shims, preventing fatal errors when `esc()`, `site_url()`, or `csrf_field()` are unavailable

## Testing
- `php -l app/Views/dashboard.php`

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691b07d5cb54833282cef8b888e5d8b2)